### PR TITLE
fix QQ redirect uri is illegal(100010)

### DIFF
--- a/src/OAuthClient.php
+++ b/src/OAuthClient.php
@@ -18,9 +18,11 @@ class OAuthClient {
         $clientId = \Config::get('oauth-client.consumers.'.$provider.'.clientId');
         $clientSecret = \Config::get('oauth-client.consumers.'.$provider.'.clientSecret');
         $className = \Config::get('oauth-client.consumers.'.$provider.'.className');
+        $redirectUri  = \Config::get('oauth-client.consumers.'.$provider.'.redirectUri');
         $model = new $className(array(
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,
+            'redirectUri' => $redirectUri
         ));
 
         return $model;


### PR DESCRIPTION
fix QQ redirect uri is illegal(100010)
修复QQ OAuth登录时由于redirectUri和QQ开放平台后台配置的地址不一致导致验证失败
